### PR TITLE
feat: update docker-compose

### DIFF
--- a/docker/docker-compose-teddynote.yaml
+++ b/docker/docker-compose-teddynote.yaml
@@ -393,7 +393,7 @@ x-shared-env: &shared-api-worker-env
 services:
   # API service
   api:
-    image: langgenius/dify-api:1.3.1
+    image: langgenius/dify-api:1.4.1
     restart: always
     environment:
       # Use the shared environment variables.
@@ -416,7 +416,7 @@ services:
   # worker service
   # The Celery worker for processing the queue.
   worker:
-    image: langgenius/dify-api:1.3.1
+    image: langgenius/dify-api:1.4.1
     restart: always
     environment:
       # Use the shared environment variables.
@@ -438,7 +438,7 @@ services:
 
   # Frontend web application.
   web:
-    image: langgenius/dify-web:1.3.1
+    image: langgenius/dify-web:1.4.1
     restart: always
     environment:
       CONSOLE_API_URL: ${CONSOLE_API_URL:-}


### PR DESCRIPTION
image: ghcr.io/open-webui/open-webui:main
image: ghcr.io/open-webui/pipelines:main

(open-web-ui는 상단처럼 이미 main이어서 손대지 않음)

`./docker` 내부에 있는 `docker-compose-teddynote.yaml` 파일 기준으로 dify-api와 dify-web image만 최신 기준으로 업데이트 하였습니다.

[dify/docker](https://github.com/langgenius/dify/blob/main/docker/docker-compose.yaml) -> 참조 후 최신으로 버전 변경